### PR TITLE
CPD-1569: Rescue exceptions when attempting to fork.

### DIFF
--- a/aws-flow/lib/aws/decider/executor.rb
+++ b/aws-flow/lib/aws/decider/executor.rb
@@ -82,6 +82,10 @@ module AWS
         end
         @log.debug "Created a new child process: parent=#{Process.pid}, child_pid=#{child_pid}"
         @pids << child_pid
+      rescue => e
+        # Failing to rescue exceptions here results in some worker processes
+        # exiting, leaving the service in an inconsistent state.
+        @log.error "Error creating a new child process: parent=#{Process.pid}, error=#{e}"
       end
 
       def shutdown(timeout_seconds)


### PR DESCRIPTION
If an exception is hit when a fork is attempted (such as ENOMEM) in order to work an activity then the main process will exit.  The worker service will continue to run but may no longer have any activity processes after some time.  This results in worker processes starting workflows but no activity processes to process the activities.